### PR TITLE
#7 fix: refactor AWS CLI into a bash script

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,11 +6,7 @@ tasks:
     env:
       AWS_CLI_AUTO_PROMPT: on-partial
     before: |
-      cd /workspace
-      curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-      unzip awscliv2.zip
-      sudo ./aws/install
-      cd $THEIA_WORKSPACE_ROOT
+      bin/install_terraform_cli
 vscode:
   extensions:
     - amazonwebservices.aws-toolkit-vscode

--- a/README.md
+++ b/README.md
@@ -152,3 +152,28 @@ gp env HELLO='world'
 All future workspaces launched will set the env vars for all bash terminals opened in thoes workspaces.
 
 You can also set en vars in the `.gitpod.yml` but this can only contain non-senstive env vars.
+
+### AWS CLI Installation
+
+AWS CLI is installed for the project via the bash script [`./bin/install_aws_cli`](./bin/install_aws_cli)
+
+
+[Getting Started Install (AWS CLI)](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+[AWS CLI Env Vars](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html)
+
+We can check if our AWS credentials is configured correctly by running the following AWS CLI command:
+```sh
+aws sts get-caller-identity
+```
+
+If it is succesful you should see a json payload return that looks like this:
+
+```json
+{
+    "UserId": "AIEAVUO15ZPVHJ5WIJ5KR",
+    "Account": "123456789012",
+    "Arn": "arn:aws:iam::123456789012:user/terraform-teratown-project"
+}
+```
+
+We'll need to generate AWS CLI credits from IAM User in order to the user AWS CLI.

--- a/bin/install_aws_cli
+++ b/bin/install_aws_cli
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+cd /workspace
+
+rm -f '/workspace/awscliv2.zip'
+rm -rf '/workspace/aws'
+
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install
+
+aws sts get-caller-identity
+
+cd $PROJECT_ROOT


### PR DESCRIPTION
- [x] Refactor AWS CLI into bash script
- [x] Provide env var examples for AWS CLI requirements
- [x] Set our env vars for AWS using gp env