### PR TITLE
#13 fix: gitpod.yml aws cli install file name correctly updated

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,7 +6,7 @@ tasks:
     env:
       AWS_CLI_AUTO_PROMPT: on-partial
     before: |
-      bin/install_terraform_cli
+      source ./bin/install_aws_cli
 vscode:
   extensions:
     - amazonwebservices.aws-toolkit-vscode


### PR DESCRIPTION
 AWS CLI install fails due to wrong name called in the gitpod.yml file