### PR TITLE
#25 feat: bucket should no longer use random provider

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -23,23 +23,3 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:b5a495582adb2c92cff67013c9083f7a08b9295e29af816c541177eb989a20ee",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/random" {
-  version     = "3.5.1"
-  constraints = "3.5.1"
-  hashes = [
-    "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
-    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
-    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
-    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
-    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
-    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
-    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
-    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
-    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
-    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
-    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
-  ]
-}

--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@
 
 ## Extras
 - [Github Markdown TOC (Table of Contents) Generator](https://ecotrust-canada.github.io/markdown-toc/)
+

--- a/journal/week1.md
+++ b/journal/week1.md
@@ -130,3 +130,25 @@ variable "instance_types" {
 ```
 
 This variable instance_types is a list of strings, with a default value of `["t2.micro", "t2.small", "t2.medium"]`. This variable could be used in your Terraform configuration to specify the instance types for an AWS Auto Scaling group, for instance [upcloud.com](https://upcloud.com/resources/tutorials/terraform-variables).
+
+
+## Dealing With Configuration Drift
+
+## What happens if we lose our state file?
+
+If you lose your statefile, you most likley have to tear down all your cloud infrastructure manually.
+
+You can use terraform port but it won't for all cloud resources. You need check the terraform providers documentation for which resources support import.
+
+### Fix Missing Resources with Terraform Import
+
+`terraform import aws_s3_bucket.bucket bucket-name`
+
+[Terraform Import](https://developer.hashicorp.com/terraform/cli/import)
+[AWS S3 Bucket Import](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#import)
+
+### Fix Manual Configuration
+
+If someone goes and delete or modifies cloud resource manually through ClickOps. 
+
+If we run Terraform plan is with attempt to put our infrstraucture back into the expected state fixing Configuration Drift

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,9 @@
-# https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string
-resource "random_string" "bucket_name" {
-  lower = true
-  upper = false
-  length   = 32
-  special  = false
-}
 
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
-resource "aws_s3_bucket" "example" {
+resource "aws_s3_bucket" "website_bucket" {
   # Bucket Naming Rules
   #https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html?icmpid=docs_amazons3_console
-  bucket = random_string.bucket_name.result
+  bucket = var.bucket_name
 
   tags = {
     UserUuid = var.user_uuid

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
-output "random_bucket_name" {
-  value = random_string.bucket_name.result
+output "bucket_name" {
+  value = aws_s3_bucket.website_bucket.bucket
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,23 +1,19 @@
 terraform {
   #backend "remote" {
   #  hostname = "app.terraform.io"
-  #  organization = "ExamPro"
+  #  organization = "ohary37"
 
   #  workspaces {
   #    name = "terra-house-1"
   #  }
   #}
-  #cloud {
-  #  organization = "ExamPro"
+  # cloud {
+  #  organization = "ohary37"
   #  workspaces {
   #    name = "terra-house-1"
   #  }
-  #}
+  # }
   required_providers {
-    random = {
-      source = "hashicorp/random"
-      version = "3.5.1"
-    }
     aws = {
       source = "hashicorp/aws"
       version = "5.16.2"
@@ -26,7 +22,4 @@ terraform {
 }
 
 provider "aws" {
-}
-provider "random" {
-  # Configuration options
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,1 +1,2 @@
 user_uuid="f360341c-994e-4bc0-bb9e-822df87902dc"
+bucket_name="tf-ohary-bucket-f360341c-994e-4bc0-bb9e-822df87902dc"

--- a/variables.tf
+++ b/variables.tf
@@ -6,3 +6,16 @@ variable "user_uuid" {
     error_message    = "The user_uuid value is not a valid UUID."
   }
 }
+
+variable "bucket_name" {
+  description = "The name of the S3 bucket"
+  type        = string
+
+  validation {
+    condition     = (
+      length(var.bucket_name) >= 3 && length(var.bucket_name) <= 63 && 
+      can(regex("^[a-z0-9][a-z0-9-.]*[a-z0-9]$", var.bucket_name))
+    )
+    error_message = "The bucket name must be between 3 and 63 characters, start and end with a lowercase letter or number, and can contain only lowercase letters, numbers, hyphens, and dots."
+  }
+}


### PR DESCRIPTION
 use terraform import
 purposely cause configuration drift via clickops, and correct state.